### PR TITLE
Update `macos-13` to `macos-latest`

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13]
+        os: [macos-latest]
         qt-version: [5.15.2, 6.5.0]
         plugins: [false]
       fail-fast: false


### PR DESCRIPTION
https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/